### PR TITLE
Object parameters supports containerImage case

### DIFF
--- a/azext/batch/_template_utils.py
+++ b/azext/batch/_template_utils.py
@@ -413,7 +413,10 @@ def _get_template_params(template, param_values):
                 # ARM: '<PropertyName>' : { 'value' : '<PropertyValue>' }
                 # Dictionary: '<PropertyName>' : <PropertyValue>'
                 value = param_values[param]
-                param_keys[param] = value.get('value') if isinstance(value, dict) else value
+                if isinstance(value, dict) and value.get('value') != None:
+                    param_keys[param] = armStyleValue
+                else:
+                    param_keys[param] = value
             except KeyError:
                 param_keys[param] = values.get('defaultValue')
     except KeyError:
@@ -453,7 +456,9 @@ def _parse_arm_parameter(name, template_obj, parameters):
                 template_obj,
                 parameters)
     except KeyError:
-        raise ValueError("Template does not define parameter '{}'".format(param_name))
+        #this is ok in the case when the parameter name isn't defined in the template_obj ahead of time
+        pass
+        #raise ValueError("Template does not define parameter '{}'".format(param_name))
 
     user_value = param_def.get('defaultValue') if isinstance(param_def, dict) else param_def
     if parameters and param_name in parameters:

--- a/azext/batch/_template_utils.py
+++ b/azext/batch/_template_utils.py
@@ -414,7 +414,7 @@ def _get_template_params(template, param_values):
                 # Dictionary: '<PropertyName>' : <PropertyValue>'
                 value = param_values[param]
                 if isinstance(value, dict) and value.get('value') != None:
-                    param_keys[param] = armStyleValue
+                    param_keys[param] = value.get('value')
                 else:
                     param_keys[param] = value
             except KeyError:

--- a/azext/batch/_template_utils.py
+++ b/azext/batch/_template_utils.py
@@ -382,6 +382,8 @@ def _validate_parameter(name, content, value):
             value = _validate_bool(value)
         elif content['type'] == 'string':
             value = _validate_string(value, content)
+        elif content['type'] == 'object':
+            pass
         else:
             raise ValueError("The parameter '{}' specifies an unsupported "
                              "type: {}".format(name, content['type']))
@@ -456,9 +458,8 @@ def _parse_arm_parameter(name, template_obj, parameters):
                 template_obj,
                 parameters)
     except KeyError:
-        #this is ok in the case when the parameter name isn't defined in the template_obj ahead of time
-        pass
-        #raise ValueError("Template does not define parameter '{}'".format(param_name))
+        if param_def.get('type') != 'object':
+            raise ValueError("Template does not define parameter '{}'".format(param_name))
 
     user_value = param_def.get('defaultValue') if isinstance(param_def, dict) else param_def
     if parameters and param_name in parameters:

--- a/azext/batch/_template_utils.py
+++ b/azext/batch/_template_utils.py
@@ -415,10 +415,7 @@ def _get_template_params(template, param_values):
                 # ARM: '<PropertyName>' : { 'value' : '<PropertyValue>' }
                 # Dictionary: '<PropertyName>' : <PropertyValue>'
                 value = param_values[param]
-                if isinstance(value, dict) and value.get('value') != None:
-                    param_keys[param] = value.get('value')
-                else:
-                    param_keys[param] = value
+                param_keys[param] = value.get('value') if isinstance(value, dict) else value
             except KeyError:
                 param_keys[param] = values.get('defaultValue')
     except KeyError:

--- a/azure-batch-cli-extensions.sln
+++ b/azure-batch-cli-extensions.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.645
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "azure-batch-cli-extensions", "azure-batch-cli-extensions.pyproj", "{938454F7-93BD-41A7-84B2-3C89D64B969D}"
 EndProject
@@ -16,8 +16,5 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {D03D6021-E2EB-4615-A789-CB067E11E99D}
 	EndGlobalSection
 EndGlobal

--- a/azure-batch-cli-extensions.sln
+++ b/azure-batch-cli-extensions.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.645
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{888888A0-9F3D-457C-B088-3A5042F75D52}") = "azure-batch-cli-extensions", "azure-batch-cli-extensions.pyproj", "{938454F7-93BD-41A7-84B2-3C89D64B969D}"
 EndProject
@@ -16,5 +16,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {D03D6021-E2EB-4615-A789-CB067E11E99D}
 	EndGlobalSection
 EndGlobal

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1607,6 +1607,38 @@ class TestBatchExtensions(unittest.TestCase):
         assert out["value2"] == "Small"
         assert out["value3"] == "firstSubnet"
 
+    def test_template_parsing_variables_undefined_in_parameter(self):
+        obj = {
+            "parameters": {
+                "containerImageParam": {
+                    "type": "object"
+                }
+            },
+            "variables": {
+                "osType": {
+                    "containerConfiguration": { 
+                      "containerImageNames": [ 
+                        "[parameters('containerImageParam').containerImage]"
+                      ]
+                    }
+                }
+            },
+            "pool": {
+                "virtualMachineConfiguration": "[variables('osType')]",
+                "applicationLicenses":  [
+                  "[parameters('containerImageParam').renderer]"
+                ]
+            }
+        }
+        param = {
+            "containerImageParam": {
+                "containerImage": "testContainerImage",
+                "renderer": "testRenderer"
+            }    
+        }
+        out = utils.expand_template(obj, param)
+        assert out["pool"]["virtualMachineConfiguration"]["containerConfiguration"]["containerImageNames"] == ["testContainerImage"]
+        assert out["pool"]["applicationLicenses"] == ["testRenderer"]
 
     def test_batch_template_reject(self):
         with open(os.path.join(self.data_dir, 'batch.job.simple.apiversionfail.json'), 'r') as template:


### PR DESCRIPTION
Loosens some of the restrictions around validating object types, so they can be empty in template without object properties being defined