### PR TITLE
Revert "This code is equivalent - use the shorter version"

### DIFF
--- a/azext/batch/_template_utils.py
+++ b/azext/batch/_template_utils.py
@@ -415,7 +415,10 @@ def _get_template_params(template, param_values):
                 # ARM: '<PropertyName>' : { 'value' : '<PropertyValue>' }
                 # Dictionary: '<PropertyName>' : <PropertyValue>'
                 value = param_values[param]
-                param_keys[param] = value.get('value') if isinstance(value, dict) else value
+                if isinstance(value, dict) and value.get('value') != None:
+                    param_keys[param] = value.get('value')
+                else:
+                    param_keys[param] = value
             except KeyError:
                 param_keys[param] = values.get('defaultValue')
     except KeyError:


### PR DESCRIPTION
This reverts commit d7e730de1e94fc3f8e63d03bd5196aeb91b0fe97. Reading comprehension fail - code is not equivalent..